### PR TITLE
Exam/iphone number

### DIFF
--- a/iphone_number/composer.json
+++ b/iphone_number/composer.json
@@ -1,0 +1,6 @@
+
+{
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    }
+}

--- a/iphone_number/phpunit.xml
+++ b/iphone_number/phpunit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true">
+  <php>
+    <includePath>./src</includePath>
+  </php>
+</phpunit>

--- a/iphone_number/src/Model/iPhoneNumber.php
+++ b/iphone_number/src/Model/iPhoneNumber.php
@@ -1,0 +1,48 @@
+<?php
+/******************************
+ガイアックス技術選考課題 初級編
+*****************************/
+
+
+function getIPhoneNumber($year){
+  //2008年未満または2017年以上ならNullを返却
+  if(2008 < $year && $year <= 2017 ){
+    $num = (int)substr($year, -2);
+
+    if($num === 8){
+      return '3G';
+    }elseif ($num === 9) {
+      return '3GS';
+    }else{
+      return discriminant_year($num);
+    }
+    return $num;
+
+  }
+  return NULL;
+}
+
+
+
+function discriminant_year($year){
+
+  $revisionCode = '';
+
+  // iPhoneナンバリングを算出
+  $number = (int)(($year -8 ) /2 ) +3;
+
+  // 奇数年年であればSをつける
+  if($year % 2){
+    $revisionCode = 'S';
+  }
+
+  // 14年以降ならPlusも合わせて返却
+  if($year >= 14){
+    return "{$number}{$revisionCode}/{$number}{$revisionCode} Plus";
+
+  }elseif($year === 13){
+    return "{$number}{$revisionCode}/{$number}c";
+
+  }
+  return $number . $revisionCode;
+}

--- a/iphone_number/src/Model/iPhoneNumber.php
+++ b/iphone_number/src/Model/iPhoneNumber.php
@@ -6,9 +6,8 @@
 
 function getIPhoneNumber($year){
   //2008年未満または2017年以上ならNullを返却
-  if(2008 < $year && $year <= 2017 ){
+  if(2008 <= $year && $year < 2017 ){
     $num = (int)substr($year, -2);
-
     if($num === 8){
       return '3G';
     }elseif ($num === 9) {

--- a/iphone_number/src/Model/iPhoneNumber.php
+++ b/iphone_number/src/Model/iPhoneNumber.php
@@ -8,6 +8,8 @@ function getIPhoneNumber($year){
   //2008年未満または2017年以上ならNullを返却
   if(2008 <= $year && $year < 2017 ){
     $num = (int)substr($year, -2);
+
+    // 2008 2009は当てはまるものをそのまま返却
     if($num === 8){
       return '3G';
     }elseif ($num === 9) {
@@ -35,13 +37,15 @@ function discriminant_year($year){
     $revisionCode = 'S';
   }
 
-  // 14年以降ならPlusも合わせて返却
+  // 2014年以降ならPlusも合わせて返却
   if($year >= 14){
     return "{$number}{$revisionCode}/{$number}{$revisionCode} Plus";
 
   }elseif($year === 13){
+    // 2013年はiPhone５Cが同時発売だった
     return "{$number}{$revisionCode}/{$number}c";
-
   }
+
+
   return $number . $revisionCode;
 }

--- a/iphone_number/src/main.php
+++ b/iphone_number/src/main.php
@@ -1,0 +1,4 @@
+<?php
+require('./Model/iPhoneNumber.php');
+
+ echo getIPhoneNumber(trim(fgets(STDIN)));

--- a/iphone_number/src/main.php
+++ b/iphone_number/src/main.php
@@ -1,4 +1,4 @@
 <?php
-require('./Model/iPhoneNumber.php');
+require(dirname(__FILE__).'/Model/iPhoneNumber.php');
 
  echo getIPhoneNumber(trim(fgets(STDIN)));

--- a/iphone_number/test/iPhoneNumberTest.php
+++ b/iphone_number/test/iPhoneNumberTest.php
@@ -1,0 +1,80 @@
+<?php
+require_once('Model/iPhoneNumber.php');
+class iPhoneNumberTest extends  PHPUnit_Framework_TestCase{
+
+
+  /**
+  * @test
+  *範囲外の数値はNULL
+  */
+  public function invalidNumber(){
+   $this->assertEquals ( NULL,getIPhoneNumber(2005));
+   $this->assertEquals ( NULL,getIPhoneNumber(2017));
+  }
+
+
+  // ここから下は入力された値と返却値が期待しているものかチェック
+
+  /**
+  * @test
+  */
+  public function iPhone2008(){
+    $this->assertEquals ( '3G',getIPhoneNumber(2008));
+  }
+
+  /**
+   * @test
+   */
+   public function iPhone2009(){
+     $this->assertEquals ( '3GS',getIPhoneNumber(2009));
+   }
+
+  /**
+  * @test
+  */
+  public function iPhone2010(){
+    $this->assertEquals ( '4',getIPhoneNumber(2010));
+  }
+
+  /**
+   * @test
+   */
+   public function iPhone2011(){
+     $this->assertEquals ( '4S',getIPhoneNumber(2011));
+   }
+
+  /**
+  * @test
+  */
+  public function iPhone2012(){
+    $this->assertEquals ( '5',getIPhoneNumber(2012));
+  }
+
+  /**
+   * @test
+   */
+   public function iPhone2013(){
+     $this->assertEquals ( '5S/5c',getIPhoneNumber(2013));
+   }
+
+   /**
+    * @test
+    */
+    public function iPhone2014(){
+      $this->assertEquals ( '6/6 Plus',getIPhoneNumber(2014));
+    }
+
+  /**
+   * @test
+   */
+   public function iPhone2015(){
+     $this->assertEquals ( '6S/6S Plus',getIPhoneNumber(2015));
+   }
+
+  /**
+  * @test
+  */
+  public function iPhone2016(){
+    $this->assertEquals ( '7/7 Plus',getIPhoneNumber(2016));
+  }
+}


### PR DESCRIPTION
## 行ったこと
任意の西暦を入力しその年に発売されたiPhoneのナンバリングを返す関数を作成しました。

## ファイル構成
 /
  │- composer.json 
   │phpunit.xml
  │- src/ 
  │ │- Model/
  │ │         └ iPhoneNumber.php  ・・・主に作成した関数
  │ └ - main.php ・・・関数を試すように作ったPHPファイル
  └ test/
               └ iPhoneNumberTest.php  ・・・今回使用したテスト


## 動作を試したPHPバージョン
```
$php -v
PHP 7.0.15 (cli) (built: Jan 22 2017 08:51:45) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2017 Zend Technologies
```

## テストコード
```
$ vendor/bin/phpunit  test