### PR TITLE
Sinshutu

### DIFF
--- a/fix_client_server/Dockerfile
+++ b/fix_client_server/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:2.3.1-slim
+
+WORKDIR /app
+COPY Gemfile /app/
+COPY Gemfile.lock /app/
+
+RUN bundle --path vendor/bundle

--- a/fix_client_server/docker-compose.yml
+++ b/fix_client_server/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+services:
+  app:
+    build: .
+    command: bundle exec rspec
+    volumes:
+      - .:/app

--- a/fix_client_server/lib/client.rb
+++ b/fix_client_server/lib/client.rb
@@ -5,7 +5,7 @@ require 'sleeper'
 class Client
 
   PERMISSION_ERROR = 'permission error'
-  FREQUENCY_REQUEST_ERROR = 'frequency request error'
+  FREQUENCY_REQUEST_ERROR = 'too many request error'
 
   def initialize
     @connection = Connection.new


### PR DESCRIPTION
# 問題となっている箇所

- サーバー側とクライアント側でリクエストが多かった場合のエラー文が異なる

- 'permission error'
  - トークンが切れていることが分かったら再度トークンを発行したい

- 'frequency request error'
	- リクエストが多い場合は、一時的に休止させたい

- 上記の問題が同時に発生する場合がある


# 対処方針
> サーバー側とクライアント側でリクエストが多かった場合のエラー文が異なる

サーバー側のエラー文とクライアント側のエラー処理を疎結合にしておくために
client.rbのFREQUENCY_REQUEST_ERRORの値をサーバー側の'too many request error'に合わせる

> 'permission error'
> 'frequency request error'
> 上記の問題が同時に発生する場合がある

1. response.rbのbodyの実装ではpermitted?をunable_to_handle?の前に実行してしまことから
requestを正常に受け取れる確率を4/5に保つために必ずリクエスト送信前にrefresh!を行う

2. 'frequency request error'になってしまう場合はsleepを行った後再度リクエスト送信を試みる

# 実装

- FREQUENCY_REQUEST_ERRORの値を'too many request error'に変更
- requestとresponseを扱いやすいようにインスタンス変数に変更
- リクエスト送信処理をしている箇所が複数存在すると考えられるので共通化するためにdo_postメソッドを作成
  post送信前にrefresh!をするように実装、今後post前に処理すべき処理が発生した場合はdo_postに追加する

- requestが成功したかどうかを確認するためにresponse_success?メソッドを作成
  確認すべきエラー項目をerrors配列にならべeachでサーバーからのレスポンスと比較する処理を実装、
	今後サーバーから返ってくるエラーが追加された場合はerrorsに追加する
