### PR TITLE
iPhoneの名前を表示するプログラムの実装

### DIFF
--- a/iphone_number/iphone.rb
+++ b/iphone_number/iphone.rb
@@ -1,0 +1,33 @@
+def get_name(year)
+    i = 2010  #2010年のiPhone4を基準に2年毎に数字が1ずつ増えるため
+    even_number = 4 + (year - i)/2  #西暦が偶数の場合に名前を求める式
+    odd_number = (4 + ((year-1) - i)/2).to_s + 's' #西暦が奇数の場合に名前を求める式
+    case year
+      when 0..2006
+        puts "iPhoneがまだ世に存在しません"
+      when 2007
+        puts '初代iPhone'
+      when 2008
+        puts '3G'
+      when 2009
+        puts '3GS'
+      when 2010..2013
+        if (year - i) % 2 == 0
+          puts even_number
+        else
+          puts odd_number
+        end
+      when 2014..2016 #2014年以降にPlusが追加されたため
+        if (year - i) % 2 == 0
+          puts "#{even_number}/#{even_number}Plus "
+        else
+          puts "#{odd_number}/#{odd_number}Plus "
+        end
+      else
+        puts "#{year}年版はまだ未発売です"
+    end
+end
+
+puts '任意の西暦を入力しましょう！その年のiPhoneの名前を表示します'
+year = gets.to_i
+get_name(year)


### PR DESCRIPTION
# 実装内容
西暦を入力するとiPhoneの名前を表示するプログラムの実装

・2007年より前はiPhoneが存在しないことを表示
・2007年〜2009年は、この期間のみイレギュラーで名前が3Gや3GSとなるため、規則性等を考えずにcase文でそのまま表示
・2010年のiPhone4を基準に、2年毎に数字が増えるようにメソッド内に変数を設定
（⇒西暦が、偶数と奇数の場合で名前の数字に「s」がつくか、つかないかを判定）
・2010〜2013年は、「s」がつくかつかないか、2014年からはそれに加えて『Plus』が追加表示される
・2017年以降は未発売であることを表示


# 備考
課題文より、iPhoneの名前の数字の規則性と『s』や『Plus』が表示されるよう実装
iPhone5cやiPhoneSEは今回の実装では表示されない。

# 課題選定の背景
完全未経験でプログラミング学習開始1か月程度と実力がまだまだであるので、初級問題を選択しました。

# 表示されるIPhone名
2007年・・・初代iPhone
2008年・・・iPhone3G
2009年・・・iPhone3GS
2010年・・・iPhone 4
2011年・・・iPhone 4s
2012年・・・iPhone 5
2013年・・・iPhone 5s
2014年・・・iPhone 6/6 Plus
2015年・・・iPhone 6s/6s Plus
2016年・・・iPhone 7/7 Plus   
2017年・・・iPhone 7s/7s Plus